### PR TITLE
Fix variable redeclaration issue

### DIFF
--- a/script.js
+++ b/script.js
@@ -72,7 +72,6 @@ let zombies = [];
 let companions = [];
 let inventory = [];
 let players = {};
-let worldState = {};
 
 // Server connection
 let socket;


### PR DESCRIPTION
## Summary
- remove stray worldState definition causing redeclaration errors

## Testing
- `node script.js` *(fails: window is not defined)*
- `npm test` *(fails: Missing script)*